### PR TITLE
docs: update site metadata for SEO

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,6 +9,7 @@ import Management from "@site/src/components/management";
 import Stylisation from "@site/src/components/styles";
 import Validation from "@site/src/components/validations";
 import More from "@site/src/components/more";
+import trivuleLogo from "@site/static/img/logo.png";
 
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
@@ -16,6 +17,8 @@ export default function Home() {
     <Layout
       title={`${siteConfig.title}`}
       description="Trivule is a library that simplifies web form validation, making it a seamless, intuitive, and effortless experience."
+      image={trivuleLogo}
+      url="https://trivule.com"
     >
       <Banner />
       <div className={clsx("features")}>


### PR DESCRIPTION
Update the site metadata in the Layout component to improve SEO:
- Set title with the site config title
- Add a meta description for the site
- Set the Open Graph image to the trivuleLogo
- Set the canonical URL to https://trivule.com